### PR TITLE
feat: function to generate monotonic ULIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A postgres extension to support [ulid][].
 
 1. [Why should I use this?](#why-should-i-use-this)
 2. [Why should I use ulid over uuid?](#why-should-i-use-ulid-over-uuid)
-3. [Usage](#usage)
-4. [Installation](#installation)
+3. [Monotonicity](#monotonicity)
+4. [Usage](#usage)
+5. [Installation](#installation)
 
 ## Why should I use this?
 
@@ -111,27 +112,80 @@ ulid=# EXPLAIN ANALYSE INSERT INTO ulid_keys(id) SELECT gen_ulid() FROM generate
 
 ## Monotonicity
 
-This extension supports [monotonicity][] through `gen_monotonic_ulid()` function. To achive this it uses PostgreSQL's shared memory and LWLock to store last generated ULID.
+This extension supports [monotonicity][] through `gen_monotonic_ulid()` function. To achive this, it uses PostgreSQL's shared memory and LWLock to store last generated ULID.
 
-Pros:
+To be able to use [monotonic][monotonicity] ULID's, it is necessary to add this extension to `postgresql.conf`'s `shared_preload_libraries` configuration setting.
+
+```conf
+shared_preload_libraries = 'ulid'	# (change requires restart)
+```
+
+<details>
+
+```
+ulid=# EXPLAIN ANALYSE SELECT gen_ulid() FROM generate_series(1, 1000000);
+                                                            QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------------
+ Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=32) (actual time=47.207..2908.978 rows=1000000 loops=1)
+ Planning Time: 0.035 ms
+ Execution Time: 4053.482 ms
+(3 rows)
+
+ulid=# EXPLAIN ANALYSE SELECT gen_monotonic_ulid() FROM generate_series(1, 1000000);
+                                                            QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------------
+ Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=32) (actual time=46.479..2586.654 rows=1000000 loops=1)
+ Planning Time: 0.037 ms
+ Execution Time: 3693.901 ms
+(3 rows)
+```
+
+</details>
+
+<details>
+
+```
+ulid=# EXPLAIN ANALYZE INSERT INTO users (name) SELECT 'Client 1' FROM generate_series(1, 1000000);
+                                                               QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Insert on users  (cost=0.00..12500.00 rows=0 width=0) (actual time=8418.257..8418.261 rows=0 loops=1)
+   ->  Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=64) (actual time=99.804..3013.333 rows=1000000 loops=1)
+ Planning Time: 0.066 ms
+ Execution Time: 8419.571 ms
+(4 rows)
+
+ulid=# EXPLAIN ANALYZE INSERT INTO users (name) SELECT 'Client 2' FROM generate_series(1, 1000000);
+                                                               QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Insert on users  (cost=0.00..12500.00 rows=0 width=0) (actual time=8359.558..8359.561 rows=0 loops=1)
+   ->  Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=64) (actual time=64.449..2976.754 rows=1000000 loops=1)
+ Planning Time: 0.090 ms
+ Execution Time: 8360.840 ms
+(4 rows)
+```
+
+</details>
+
+<!-- omit from toc -->
+### Pros
 
 1. Monotonic ULIDs are better for indexing, as they are sorted by default.
-
 2. Monotonic ULIDs slightly faster than `gen_ulid()` when generating lots of ULIDs within one millisecond. Because, in this case, there is no need to generate random component of ULID. Instead it is just incremented.
 
-Cons:
+<!-- omit from toc -->
+### Cons
 
 1. Previously generated ULID is saved in shmem and accessed via LWLock. i.e. it is exclusive for function invocation within database. Theoretically this can lead to slowdowns.
 
-   *...But, in practice (at least in my testing) `gen_monotonic_ulid()` is slightly faster than `gen_ulid()` (see Pros.2).*
+    *...But, in practice (at least in our testing) `gen_monotonic_ulid()` is slightly faster than `gen_ulid()`.*
 
 2. Extensions that use shared memory must be loaded via `postgresql.conf`'s `shared_preload_libraries` configuration setting.
 
-   *...But, it only affects `gen_monotonic_ulid()` function. Other functions of this extension will work normally even without this config.*
+    *...But, it only affects `gen_monotonic_ulid()` function. Other functions of this extension will work normally even without this config.*
 
 3. Monotonic ULIDs may overflow and throw an error.
 
-   *...But, chances are negligible.*
+    *...But, chances are negligible.*
 
 ## Usage
 
@@ -177,12 +231,6 @@ ADD COLUMN created_at timestamp GENERATED ALWAYS AS (id::timestamp) STORED;
 Use [pgrx][]. You can clone this repo and install this extension locally by following [this guide](https://github.com/tcdi/pgrx/blob/master/cargo-pgrx/README.md#installing-your-extension-locally).
 
 You can also download relevant files from [releases](https://github.com/pksunkara/pgx_ulid/releases) page.
-
-To be able to use [monotonic][monotonicity] [ulid][]'s it is necessary to add this extension to `postgresql.conf`'s `shared_preload_libraries` configuration setting.
-
-```conf
-shared_preload_libraries = 'ulid'	# (change requires restart)
-```
 
 <!-- omit from toc -->
 ## Contributors


### PR DESCRIPTION
This commit adds `gen_monotonic_ulid()` function, which generates ULIDs with monotonicity as described in
[spec](https://github.com/ulid/spec#monotonicity). To achive this it uses PostgreSQL's shared memory and LWLock to store last generated ULID.

Pros:

    1. Monotonic ULIDs are better for indexing, as they are sorted by
       default.

    2. Monotonic ULIDs slightly faster than `gen_ulid()` when generating
       lots of ULIDs within one millisecond. Because, in this case,
       there is no need to generate random component of ULID. Instead it
       is just incremented.

Cons:

    1. Previously generated ULID is saved in shmem and accessed via LWLock.
       i.e. it is exclusive for function invocation within database.
       Theoretically this can lead to slowdowns.

       ...But, in practice (at least in my testing) `gen_monotonic_ulid()`
       is slightly faster than `gen_ulid()` (see Pros.2).

    2. Extensions that use shared memory must be loaded via
       postgresql.conf's shared_preload_libraries configuration setting.

       ...But, it only affects `gen_monotonic_ulid()` function. Other
       functions of this extension will work normally even without this
       config.

    3. Monotonic ULIDs may overflow and throw an error.

       ...But, chances are negligible.

Tests:

GENERATION

```sql
ulid=# EXPLAIN ANALYSE SELECT gen_ulid() FROM generate_series(1, 1000000);
                                                            QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------
 Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=32) (actual time=47.207..2908.978 rows=1000000 loops=1)
 Planning Time: 0.035 ms
 Execution Time: 4053.482 ms
(3 rows)

ulid=# EXPLAIN ANALYSE SELECT gen_monotonic_ulid() FROM generate_series(1, 1000000);
                                                            QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------
 Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=32) (actual time=46.479..2586.654 rows=1000000 loops=1)
 Planning Time: 0.037 ms
 Execution Time: 3693.901 ms
(3 rows)
```

INSERTION

First, `gen_ulid()`

```sql
ulid=# CREATE TABLE users (
  id ulid NOT NULL DEFAULT gen_ulid() PRIMARY KEY,
  name text NOT NULL
);
CREATE TABLE
```

Next queries launched in parrallel (as much as possible) from different clients (psql)

```sql
ulid=# -- Client 1
ulid=# EXPLAIN ANALYZE INSERT INTO users (name) SELECT 'Client 1' FROM generate_series(1, 1000000);
                                                               QUERY PLAN

-----------------------------------------------------------------------------------------------------------------------------------------
 Insert on users  (cost=0.00..12500.00 rows=0 width=0) (actual time=8418.257..8418.261 rows=0 loops=1)
   ->  Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=64) (actual time=99.804..3013.333 rows=1000000 loops=1)
 Planning Time: 0.066 ms
 Execution Time: 8419.571 ms
(4 rows)

```

```sql
ulid=# -- Client 2
ulid=# EXPLAIN ANALYZE INSERT INTO users (name) SELECT 'Client 2' FROM generate_series(1, 1000000);
                                                               QUERY PLAN

-----------------------------------------------------------------------------------------------------------------------------------------
 Insert on users  (cost=0.00..12500.00 rows=0 width=0) (actual time=8359.558..8359.561 rows=0 loops=1)
   ->  Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=64) (actual time=64.449..2976.754 rows=1000000 loops=1)
 Planning Time: 0.090 ms
 Execution Time: 8360.840 ms
(4 rows)

```

Snippet from table

```
ulid=# SELECT id, name, id::timestamp as ts FROM users WHERE id::timestamp = '2023-06-14 18:02:15.089'::timestamp LIMIT 10;
             id             |   name   |           ts
----------------------------+----------+-------------------------
 01H2XMJYSH02BV5G5NNXF2F93Z | Client 2 | 2023-06-14 18:02:15.089
 01H2XMJYSH0HAQ63M6275PTQTP | Client 2 | 2023-06-14 18:02:15.089
 01H2XMJYSH13K8J4RGWEM0TMV3 | Client 2 | 2023-06-14 18:02:15.089
 01H2XMJYSH174Q04GFZNJKS3AP | Client 2 | 2023-06-14 18:02:15.089
 01H2XMJYSH19PWNYC4X7Q53J4B | Client 1 | 2023-06-14 18:02:15.089
 01H2XMJYSH1WM0NH5W7QHSEST3 | Client 2 | 2023-06-14 18:02:15.089
 01H2XMJYSH27VYJY40HWWA4BAR | Client 2 | 2023-06-14 18:02:15.089
 01H2XMJYSH2911P1Y9Y7N55RJM | Client 2 | 2023-06-14 18:02:15.089
 01H2XMJYSH2DER9A5QBCACBGEQ | Client 1 | 2023-06-14 18:02:15.089
 01H2XMJYSH2F51ZERVPSD52D6Z | Client 2 | 2023-06-14 18:02:15.089
(10 rows)
```

Now, `gen_monotonic_ulid()`

```sql
ulid=# CREATE TABLE users (
  id ulid NOT NULL DEFAULT gen_monotonic_ulid() PRIMARY KEY,
  name text NOT NULL
);
CREATE TABLE
```

Next queries launched in parrallel (as much as possible) from different clients (psql)

```sql
ulid=# -- Client 1
ulid=# EXPLAIN ANALYZE INSERT INTO users (name) SELECT 'Client 1' FROM generate_series(1, 1000000);
                                                               QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------
 Insert on users  (cost=0.00..12500.00 rows=0 width=0) (actual time=6534.466..6534.471 rows=0 loops=1)
   ->  Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=64) (actual time=77.349..2778.529 rows=1000000 loops=1)
 Planning Time: 0.063 ms
 Execution Time: 6535.592 ms
(4 rows)
```

```sql
ulid=# -- Client 2
ulid=# EXPLAIN ANALYZE INSERT INTO users (name) SELECT 'Client 2' FROM generate_series(1, 1000000);
                                                               QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------
 Insert on users  (cost=0.00..12500.00 rows=0 width=0) (actual time=6568.836..6568.841 rows=0 loops=1)
   ->  Function Scan on generate_series  (cost=0.00..12500.00 rows=1000000 width=64) (actual time=53.712..2757.347 rows=1000000 loops=1)
 Planning Time: 0.058 ms
 Execution Time: 6570.180 ms
(4 rows)
```

Snippet from table

```
oml=# SELECT id, name, id::timestamp as ts FROM users WHERE id::timestamp = '2023-06-14 18:26:52.719'::timestamp LIMIT 10;
             id             |   name   |           ts
----------------------------+----------+-------------------------
 01H2XP01SFR6QVRDC7X4Q562ZV | Client 1 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q562ZW | Client 2 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q562ZX | Client 1 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q562ZY | Client 2 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q562ZZ | Client 1 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q56300 | Client 2 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q56301 | Client 1 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q56302 | Client 2 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q56303 | Client 1 | 2023-06-14 18:26:52.719
 01H2XP01SFR6QVRDC7X4Q56304 | Client 2 | 2023-06-14 18:26:52.719
(10 rows)
```