### PR TITLE
Use pgrx 0.10.0-beta.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.70.0
+        uses: dtolnay/rust-toolchain@1.71.1
         with:
           components: rustfmt, clippy
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.70.0
+        uses: dtolnay/rust-toolchain@1.71.1
       - name: Install dependencies
         run: |
           # Add postgres package repo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ pg_test = []
 
 [dependencies]
 inner_ulid = { package = "ulid", version = "1.0.0" }
-pgrx       = "=0.9.7"
+pgrx       = "=0.10.0-beta.4"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.7"
+pgrx-tests = "=0.10.0-beta.4"
 
 [profile.dev]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name    = "ulid"
 publish = false
-version = "0.1.1"
+version = "0.1.2-rc.0"
 
 edition      = "2021"
 rust-version = "1.70.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,13 @@ RUN chown postgres:postgres /home/postgres
 USER postgres
 
 RUN \
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain 1.70.0 && \
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain 1.71.1 && \
   rustup --version && \
   rustc --version && \
   cargo --version
 
 # pgrx
-RUN cargo install cargo-pgrx --version 0.9.7 --locked
+RUN cargo install cargo-pgrx --version 0.10.0-beta.4 --locked
 
 RUN cargo pgrx init --pg${PG_MAJOR} $(which pg_config)
 


### PR DESCRIPTION
I figured it may be convenient to draft a patch for use by anyone who may need a version patched to use the latest `pgrx`, whether or not the author of `pgx_ulid` intends to merge and publish this.