### PR TITLE
Add function to convert from timestamp to ULID

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ ALTER TABLE users
 ADD COLUMN created_at timestamp GENERATED ALWAYS AS (id::timestamp) STORED;
 ```
 
+Cast timestamp to [ulid][]:
+
+```sql
+-- gets all users where the ID was created on 2023-09-15, without using another column and taking advantage of the index
+SELECT * FROM users WHERE id BETWEEN timestamp_to_ulid('2023-09-15') AND '2023-09-16'::timestamp::ulid;
+```
+
 ## Installation
 
 Use [pgrx][]. You can clone this repo and install this extension locally by following [this guide](https://github.com/tcdi/pgrx/blob/master/cargo-pgrx/README.md#installing-your-extension-locally).

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ ALTER TABLE users
 ADD COLUMN created_at timestamp GENERATED ALWAYS AS (id::timestamp) STORED;
 ```
 
-Cast timestamp to [ulid][]:
+Cast timestamp to [ulid][], this generates a zeroed ULID with the timestamp prefixed (TTTTTTTTTT0000000000000000):
 
 ```sql
 -- gets all users where the ID was created on 2023-09-15, without using another column and taking advantage of the index

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Cast timestamp to [ulid][], this generates a zeroed ULID with the timestamp pref
 
 ```sql
 -- gets all users where the ID was created on 2023-09-15, without using another column and taking advantage of the index
-SELECT * FROM users WHERE id BETWEEN timestamp_to_ulid('2023-09-15') AND '2023-09-16'::timestamp::ulid;
+SELECT * FROM users WHERE id BETWEEN '2023-09-15'::timestamp::ulid AND '2023-09-16'::timestamp::ulid;
 ```
 
 ## Installation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,11 @@ fn ulid_to_timestamp(input: ulid) -> Timestamp {
 
 #[pg_extern(immutable, parallel_safe)]
 fn timestamp_to_ulid(input: Timestamp) -> ulid {
-    let epoch: f64 = input.extract_part(DateTimeParts::Epoch).unwrap().try_into().unwrap();
+    let epoch: f64 = input
+        .extract_part(DateTimeParts::Epoch)
+        .unwrap()
+        .try_into()
+        .unwrap();
 
     let milliseconds = (epoch * 1000.0) as u64;
 
@@ -147,7 +151,6 @@ mod tests {
     const TEXT: &str = "01GV5PA9EQG7D82Q3Y4PKBZSYV";
     const UUID: &str = "0186cb65-25d7-81da-815c-7e25a6bfe7db";
     const TIMESTAMP: &str = "2023-03-10 12:00:49.111";
-
 
     #[pg_test]
     fn test_null_to_ulid() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,6 @@ mod tests {
     const TEXT: &str = "01GV5PA9EQG7D82Q3Y4PKBZSYV";
     const UUID: &str = "0186cb65-25d7-81da-815c-7e25a6bfe7db";
     const TIMESTAMP: &str = "2023-03-10 12:00:49.111";
-    const TIMESTAMP_ULID_PREFIX: &str = "01GV5PA9EQ0000000000000000";
 
 
     #[pg_test]
@@ -197,7 +196,7 @@ mod tests {
     fn test_timestamp_to_ulid() {
         let result =
             Spi::get_one::<&str>(&format!("SELECT '{TIMESTAMP}'::timestamp::ulid::text;")).unwrap();
-        assert_eq!(Some(TIMESTAMP_ULID_PREFIX), result);
+        assert_eq!(Some("01GV5PA9EQ0000000000000000"), result);
     }
 
     #[pg_test]


### PR DESCRIPTION
Hey! This is a quick PR that I thought may be useful.
The conversion from timestamp creates a ULID with the random part zeroed (`2023-09-15 05:10:56.281000` becomes `01HABKZM0S0000000000000000`). This enables quick lookups in `WHERE` clauses using only time information but taking advantage of the index on the ID and without needing another column. This is possible because of the binary/numeric nature of the extension.

Example:
```sql
SELECT * FROM users WHERE id BETWEEN timestamp_to_ulid('2023-09-15') AND '2023-09-16'::timestamp::ulid;
```

The explain from a similar query:
```
Bitmap Heap Scan on ulidtest  (cost=4.22..14.40 rows=7 width=40) (actual time=0.020..0.021 rows=3 loops=1)
  Recheck Cond: ((id >= '01HABKZM0S0000000000000000'::ulid) AND (id <= '01HADMK0000000000000000000'::ulid))
  Heap Blocks: exact=1
  ->  Bitmap Index Scan on ulidtest_pkey  (cost=0.00..4.22 rows=7 width=0) (actual time=0.016..0.016 rows=3 loops=1)
        Index Cond: ((id >= '01HABKZM0S0000000000000000'::ulid) AND (id <= '01HADMK0000000000000000000'::ulid))
Planning Time: 0.086 ms
Execution Time: 0.032 ms
```

Thanks for making the extension and I'm open to any feedback