### PR TITLE
Add Postgres 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [14, 15]
+        postgres: [14, 15, 16]
         runner:
           - ubuntu-22.04
           - buildjet-8vcpu-ubuntu-2204-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [14, 15]
+        postgres: [14, 15, 16]
         box:
           - runner: ubuntu-22.04
             arch: amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           # Ensure installed pg_config is first on path
           export PATH=$PATH:/usr/lib/postgresql/${{ matrix.postgres }}/bin
 
-          cargo install cargo-pgrx --version 0.10.0-beta.4 --locked
+          cargo install cargo-pgrx --version 0.10.2 --locked
           cargo pgrx init --pg${{ matrix.postgres }}=/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config
       - name: Build artifacts
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ pg_test = []
 
 [dependencies]
 inner_ulid = { package = "ulid", version = "1.0.0" }
-pgrx       = "=0.10.0-beta.4"
+pgrx       = "=0.10.2"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.0-beta.4"
+pgrx-tests = "=0.10.2"
 
 [profile.dev]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pg12    = ["pgrx-tests/pg12", "pgrx/pg12"]
 pg13    = ["pgrx-tests/pg13", "pgrx/pg13"]
 pg14    = ["pgrx-tests/pg14", "pgrx/pg14"]
 pg15    = ["pgrx-tests/pg15", "pgrx/pg15"]
+pg16    = ["pgrx-tests/pg16", "pgrx/pg16"]
 pg_test = []
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
   cargo --version
 
 # pgrx
-RUN cargo install cargo-pgrx --version 0.10.0-beta.4 --locked
+RUN cargo install cargo-pgrx --version 0.10.2 --locked
 
 RUN cargo pgrx init --pg${PG_MAJOR} $(which pg_config)
 


### PR DESCRIPTION
- Update `pgrx` to 0.10.2, add `pg16` feature (keep 15 default)
- Run CI pipeline on Postgres 16 