### PR TITLE
Use the appropriate method for unix timestamp conversion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,9 +112,8 @@ fn ulid_to_uuid(input: ulid) -> Uuid {
 
 #[pg_extern(immutable, parallel_safe)]
 fn ulid_to_timestamp(input: ulid) -> Timestamp {
-    // 946684800000 is the number of milliseconds between 1970-01-01 and 2000-01-01
-    let inner = InnerUlid(input.0).timestamp_ms() as i64 - 946_684_800_000;
-    Timestamp::try_from(inner * 1000).unwrap()
+    let inner_seconds = (InnerUlid(input.0).timestamp_ms() as f64) / 1000.0;
+    to_timestamp(inner_seconds).into()
 }
 
 #[pg_extern(immutable, parallel_safe)]


### PR DESCRIPTION
This is a quick PR just to remove any magic numbers from the `ulid_to_timestamp` method. This uses the appropriate method to convert from a Unix Epoch to a PostgreSQL Timestamp