### PR TITLE
Add docs to resolve exclusive lock error in pgx_ulid setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,16 +246,16 @@ If you encounter the exclusive lock error while using `pgx_ulid`, follow these s
 
 1. Alter the system to set `shared_preload_libraries` to `ulid` by running the following SQL command:
 
-  ```sql
-  ALTER SYSTEM SET shared_preload_libraries = 'ulid';
-  ```
+   ```sql
+   ALTER SYSTEM SET shared_preload_libraries = 'ulid';
+   ```
 
 2. Restart the PostgreSQL service to apply the changes. The command to restart PostgreSQL depends on your system.
 3. Verify that `ulid` is successfully loaded into shared libraries by executing:
 
-  ```sql
-  SHOW shared_preload_libraries;
-  ```
+   ```sql
+   SHOW shared_preload_libraries;
+   ```
 
 <!-- omit from toc -->
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A postgres extension to support [ulid][].
 3. [Monotonicity](#monotonicity)
 4. [Usage](#usage)
 5. [Installation](#installation)
+6. [Troubleshooting](#troubleshooting)
 
 ## Why should I use this?
 
@@ -238,6 +239,23 @@ SELECT * FROM users WHERE id BETWEEN '2023-09-15'::timestamp::ulid AND '2023-09-
 Use [pgrx][]. You can clone this repo and install this extension locally by following [this guide](https://github.com/tcdi/pgrx/blob/master/cargo-pgrx/README.md#installing-your-extension-locally).
 
 You can also download relevant files from [releases](https://github.com/pksunkara/pgx_ulid/releases) page.
+
+## Troubleshooting
+
+If you encounter the exclusive lock error while using `pgx_ulid`, follow these steps to resolve the issue:
+
+1. Alter the system to set `shared_preload_libraries` to `ulid` by running the following SQL command:
+
+  ```sql
+  ALTER SYSTEM SET shared_preload_libraries = 'ulid';
+  ```
+
+2. Restart the PostgreSQL service to apply the changes. The command to restart PostgreSQL depends on your system.
+3. Verify that `ulid` is successfully loaded into shared libraries by executing:
+
+  ```sql
+  SHOW shared_preload_libraries;
+  ```
 
 <!-- omit from toc -->
 ## Contributors


### PR DESCRIPTION
Fixes #12

Adds a troubleshooting section to the README.md to address the exclusive lock error when using `pgx_ulid`.

- Introduces a "Troubleshooting" section before the "License" section, providing clear steps to resolve the exclusive lock error by altering the system to set `shared_preload_libraries` to `ulid`.
- Details the process of restarting the PostgreSQL service after altering `shared_preload_libraries` to ensure changes take effect.
- Recommends verifying the change with `SHOW shared_preload_libraries;` to confirm `ulid` is successfully loaded.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pksunkara/pgx_ulid/issues/12?shareId=9b0fd900-91fe-4a49-8edb-f157744e49e4).