### PR TITLE
Use proper error code for input errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,16 @@ impl InOutFuncs for ulid {
         Self: Sized,
     {
         let val = input.to_str().unwrap();
-        let inner = InnerUlid::from_string(val)
-            .unwrap_or_else(|err| panic!("invalid input syntax for type ulid: \"{val}\": {err}"));
-
-        ulid(inner.0)
+        match InnerUlid::from_string(val) {
+            Ok(inner) => ulid(inner.0),
+            Err(err) => {
+                ereport!(
+                    ERROR,
+                    PgSqlErrorCode::ERRCODE_INVALID_TEXT_REPRESENTATION,
+                    format!("invalid input syntax for type ulid: \"{val}\": {err}")
+                );
+            }
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Before this commit, the error was reported with ERRCODE_INTERNAL_ERROR (SQLSTATE XX000):

```
postgres=# \set VERBOSITY verbose
postgres=# select 'foo'::ulid;
ERROR:  XX000: invalid input syntax for type ulid: "foo": invalid length
LINE 1: select 'foo'::ulid;
               ^
LOCATION:  lib.rs:37
```

With this, ERRCODE_INVALID_TEXT_REPRESENTATION (SQLSTATE 22P02) is used:

```
postgres=# \set VERBOSITY verbose
postgres=# select 'foo'::ulid;
ERROR:  22P02: invalid input syntax for type ulid: "foo": invalid length
LINE 1: select 'foo'::ulid;
               ^
LOCATION:  <ulid::ulid as pgrx::inoutfuncs::InOutFuncs>::input, lib.rs:39
```